### PR TITLE
feat: ADD delete image api, adjust: apply temporary s3 image mechanis…

### DIFF
--- a/api_question/actions.py
+++ b/api_question/actions.py
@@ -1,3 +1,5 @@
+import uuid
+
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
@@ -72,12 +74,15 @@ def duplicate_question(
             detail="問題不存在"
         )
 
+    new_image_url = str(uuid.uuid4())
+
     new_added_question_id, new_added_question = crud.create_question(
         form_id=form_id,
         title=question_map[question_id].title,
         description=question_map[question_id].description,
         question_type=question_map[question_id].type,
         is_required=question_map[question_id].is_required,
+        image_url=new_image_url,  # s3 圖片網址需不同
         db=db
     )
 
@@ -106,7 +111,7 @@ def duplicate_question(
         question_order=[question.id for question in questions]
     )
 
-    return new_added_question_id
+    return new_added_question_id, question_map[question_id].image_url, new_image_url
 
 
 @transaction

--- a/api_question/crud.py
+++ b/api_question/crud.py
@@ -37,6 +37,7 @@ def create_question(
         description: str = None,
         question_type: str = None,
         is_required: bool = None,
+        image_url: str = None,
         order: int = None
 ):
     question_id = str(uuid.uuid4())
@@ -52,6 +53,8 @@ def create_question(
         question.type = question_type
     if is_required:
         question.is_required = is_required
+    if image_url:
+        question.image_url = image_url
     if order:
         question.order = order
     else:
@@ -72,6 +75,13 @@ def update_question(
         question.type = fields.type
     if fields.is_required is not None:
         question.is_required = fields.is_required
+    if fields.image_url is not None:
+        # 刪除 image 的情境，會帶 "" 來更新 question.image_url
+        if fields.image_url == "":
+            question.image_url = fields.image_url
+        else:
+            # 上傳之後的圖片 key 都會是 _ 當開頭，存進 db 的時候要拿掉
+            question.image_url = fields.image_url.split('_')[1]
 
     return True
 

--- a/api_question/schemas.py
+++ b/api_question/schemas.py
@@ -14,6 +14,7 @@ class UpdateQuestionIn(BaseModel):
     description: str = Field(None, description="問題描述")
     type: int = Field(..., description="問題類型")
     is_required: bool = Field(None, description="問題是否必填")
+    image_url: str = Field(None, description="問題圖片網址")
 
 
 class DeleteQuestionIn(BaseModel):

--- a/api_tool/schemas.py
+++ b/api_tool/schemas.py
@@ -31,3 +31,10 @@ class UploadImageInForm(BaseModel):
             form_id=form_id,
             question_id=question_id
         )
+
+
+class DeleteImageIn(BaseModel):
+    delete_type: str
+    form_id: str
+    question_id: str = None
+    image_url: str

--- a/app/main.py
+++ b/app/main.py
@@ -2,8 +2,9 @@ import importlib
 import os
 import re
 from contextlib import asynccontextmanager
+from typing import Union
 
-from fastapi import Depends, FastAPI, UploadFile, File
+from fastapi import Depends, FastAPI, UploadFile, File, Body
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from sqlalchemy.orm import Session
@@ -108,7 +109,7 @@ def get_todos(db: Session = Depends(get_db)):
 @app.post(
     "/upload_image",
     description="上傳圖片(用於 form & question)",
-    response_model=bool
+    response_model=Union[bool, str]
 )
 async def upload_image(
         inputs: tool_schemas.UploadImageInForm = Depends(tool_schemas.UploadImageInForm.as_form),
@@ -116,6 +117,19 @@ async def upload_image(
         db: Session = Depends(get_db)
 ):
     result = await tool_actions.upload_image(inputs, file, db)
+    return result
+
+
+@app.delete(
+    "/image",
+    description="刪除圖片 (image_id 為 form & question 中的 image_url)",
+    response_model=bool
+)
+async def delete_image(
+        inputs: tool_schemas.DeleteImageIn = Body(..., title="刪除圖片"),
+        db: Session = Depends(get_db)
+):
+    result = await tool_actions.delete_image(inputs, db)
     return result
 
 

--- a/components/aws_s3_service.py
+++ b/components/aws_s3_service.py
@@ -31,3 +31,25 @@ async def s3_upload_object(contents: bytes, content_type, object_name, bucket=S3
         logging.error(e)
         return False
     return True
+
+
+async def s3_delete_object(object_name, bucket=S3_BUCKET):
+    try:
+        response = s3_client.delete_object(Bucket=bucket, Key=object_name)
+    except ClientError as e:
+        logging.error(e)
+        return False
+    return True
+
+
+async def s3_copy_object(copy_source, new_key, bucket=S3_BUCKET):
+    try:
+        response = s3_client.copy_object(
+            Bucket=bucket,
+            CopySource=f"{bucket}/{copy_source}",
+            Key=new_key
+        )
+    except ClientError as e:
+        logging.error(e)
+        return False
+    return True


### PR DESCRIPTION
- 上傳的圖片暫存機制 ✅
    - 初次打上傳 api 時先以 _ 當每個 key 的 prefix，例如 _12345.png
    - 打 update 問題 api 時
        1. 把 image url 寫入 (12345.png)
        2. _12345.png 在 s3 複製一份 12345.png
        3. 刪除 _12345.png
        
        **NOTE:** 
        
        - **PUT /api/question/ 前端需多帶 image_url**
            - **刪除的時候帶空字串**
            - **沒有動作時帶 None**
            - **成功上傳圖片時帶 s3 key (從 upload_image 拿回的 response)**
    - 如果上傳圖片後沒有成功 update question，則每日會有**排程**將 s3 上 temp 開頭的檔案刪除 📁
- 刪除圖片 api ✅
    - Q: 已經有圖片的情況下，如果要重新上傳，要 1. 自動刪除原本圖片 還是 2. 要規定先刪除才可以再上傳?
- 上傳圖片 api 修正 ✅
    - 限制檔案大小
    - 成功回傳 image_url
    - 順手改了邏輯:  每次上傳會再重新產一 uuid 當 image_url
- 複製 question 時圖片也要複製一份 ✅
- *刪除 s3 temp 排程 pending* 🏗️